### PR TITLE
Update `cbor` dependency, set up GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze project source
+        run: dart analyze
+
+      - name: Run tests with coverage
+        run: dart run coverage:test_with_coverage
+
+      - uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage/lcov.info
+          name: Upload to codecov.io
+          verbose: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,9 +18,9 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-raw-types: true
+    strict-casts: true
   errors:
     invalid_annotation_target: ignore  # for freezed
     missing_required_param: warning

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  cbor: ^5.0.1
+  cbor: ^6.0.0
   collection: ^1.16.0
   meta: ^1.7.0
 


### PR DESCRIPTION
This PR updates the `cbor` dependency to the latest version and sets up a GitHub actions workflow (adapted from the one used by dart_wot). It also fixes two issues with deprecated linting rules.