### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 --- 2023-07-08
+- Updated Dart SDK version constraints to include Dart 3.0.
+- Includes changes from #1 (thanks, @JKRhb!)
+    - Updated `cbor` dependency to 6.0.0.
+    - Replaced deprecated linting rules.
+    - Added GitHub Actions workflow.
+
 ## 0.1.0 --- 2022-05-12
 
 ### Changed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 repository: https://github.com/namib-project/dart_dcaf
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   cbor: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dcaf
 description: An implementation of the ACE-OAuth framework, intended for OAuth clients. Its main feature is CBOR-(de-)serializable data models.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/namib-project/dart_dcaf
 
 environment:


### PR DESCRIPTION
This PR mainly addresses some organizational TODOs for the 0.1.1 release, that is, it
- increases the version number of `dart_dcaf` to 0.1.1,
- changes the SDK constraints to include Dart 3.0, and
- updates the changelog.

After this PR is merged, I will publish a new version of this package on pub.dev.